### PR TITLE
Adding Wolters Kluwer bibsource

### DIFF
--- a/conf/bib_sources.csv
+++ b/conf/bib_sources.csv
@@ -1,4 +1,5 @@
 id,name,platform,license
+98,Wolters Kluwer-Ovid [Purchased],Ovid,purchased
 97,IGI: Purchased,IGI,purchased
 96,IGI: EBA,IGI,eba
 95,AVON-Alexander Street [Purchased],Proquest,purchased


### PR DESCRIPTION
We have purchased an ebook from Wolters Kluwer that is hosted on their Ovid platform. - Mackenzie