### PR TITLE
Update bib_sources.csv to align with database

### DIFF
--- a/conf/bib_sources.csv
+++ b/conf/bib_sources.csv
@@ -1,6 +1,8 @@
 id,name,platform,license
-99,T&F: EBA,TandF,eba
-98,Wolters Kluwer-Ovid [Purchased],Ovid,purchased
+101,T&F: EBA,TandF,eba
+100,Wolters Kluwer-Ovid [Purchased],Ovid,purchased
+99,Course materials module,local,purchased
+98,De Gruyter [Trial],De Gruyter,subscription
 97,IGI: Purchased,IGI,purchased
 96,IGI: EBA,IGI,eba
 95,AVON-Alexander Street [Purchased],Proquest,purchased


### PR DESCRIPTION
Bringing bib_sources list in line with config.bib_sources in the database. I made assumptions as to whether the De Gruyter trial was a subscription, and whether the Course materials module was local/purchased. I checked with Melissa regarding both of them and will update again if I am incorrect in my info.