### PR TITLE
Update bib_sources.csv

### DIFF
--- a/conf/bib_sources.csv
+++ b/conf/bib_sources.csv
@@ -1,4 +1,5 @@
 id,name,platform,license
+107,For OneSearch Upload [Hidden],various,oa
 106,Knowledge Unlatched [Open Access],OCLC,oa
 105,Elgar [Purchased],Elgaronline,purchased
 104,Digitalia Hispanica [Purchased],Digitalia Hispanica,purchased


### PR DESCRIPTION
Adding a new bibsource for e-resources that need an EG record in order to be uploaded to OneSearch (ie OneSearch is not collecting that information from the vendor). This may end up being entirely for Open Access or other resources we can access for free -- further work will be forthcoming to differentiate this bib source from bib source 22 (Open Access/Free). Current thinking is that one will become transcendent and OPAC visible, while one will remain hidden.